### PR TITLE
retouche fichiers

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1,6 +1,6 @@
 #include "server.h"
 
-static void init(void)
+void init(void)
 {
 #ifdef WIN32
     WSADATA wsa;
@@ -13,7 +13,7 @@ static void init(void)
 #endif
 }
 
-static void end(void)
+void end(void)
 {
 #ifdef WIN32
     WSACleanup();
@@ -62,7 +62,7 @@ int init_server_connection(int port, int nb_client){
 * @param  buffer  {char*}  buffer for msg
 * @return {int} return Buffer size
 */
-static int read_client(SOCKET sock, char *buffer)
+int read_client(SOCKET sock, char *buffer)
 {
    //printf("on passe dans le red client\n");
    int n = 0;

--- a/src/server.h
+++ b/src/server.h
@@ -1,7 +1,9 @@
 #ifdef WIN32 // if windows
+
 #include <winsock2.h>
 
 #else // if not supported
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -37,13 +39,12 @@ typedef struct in_addr IN_ADDR;
 
 #endif
 
-static int PORT =7777;
-static int MAX_CLIENT = 10;
+#define MAX_CLIENT 10
 
-static void init(void);
-static void end(void);
+void init(void);
+void end(void);
 int init_server_connection(int port, int nb_client);
-static int read_client(SOCKET sock, char *buffer);
+int read_client(SOCKET sock, char *buffer);
 void write_client(int socket_fd, char * message);
 int parse_cmd(char* buffer, char * arg);
 void cmd_pwd(SOCKET sock,char *arg);

--- a/src/server_main.c
+++ b/src/server_main.c
@@ -1,4 +1,6 @@
-#include "server.c"
+#include "server.h"
+
+int PORT = 7777;
 
 int main(int argc, char *argv[]){
 


### PR DESCRIPTION
j'ai enlevé le mot clé "static" sur certaines fonctions parce qu'à mon avis ce n'est pas utilisé à bon escient.
Le mot clé static est utilisé pour rendre les variables et fonctions invisibles en dehors des fichiers .h et .c où elles sont définies.
Mais comme tu en as besoin dans ton fichier **main** ce n'est pas une bonne idée.
En plus cela t'oblige à faire l'include du .c au lieu du .h 